### PR TITLE
Disabling travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ before_install:
 script:
   - msbuild /p:Configuration=Release Interactr/Interactr.sln
   - mono nunit/nunit3-console.exe ./Interactr.Tests/bin/Release/Interactr.Tests.dll
+notifications:
+  email: false


### PR DESCRIPTION
Because I don't want an inbox full of stupid emails telling me if the build failed or succeeded. There are websites for that. Kind of obvious why.