### PR TITLE
Fix window repainting race issues

### DIFF
--- a/Interactr/Window/CanvasWindow.cs
+++ b/Interactr/Window/CanvasWindow.cs
@@ -113,7 +113,7 @@ namespace Interactr.Window
         /// </summary>
         public void Repaint()
         {
-            if (_form.IsHandleCreated)
+            if (_form.IsHandleCreated && !_form.IsDisposed)
             {
                 if (_form.InvokeRequired)
                 {


### PR DESCRIPTION
Don't repaint if the window has not been created yet (or has been disposed), and don't use invoke unless necessary.